### PR TITLE
fix: Typos

### DIFF
--- a/src/compiling/failing/logger.rs
+++ b/src/compiling/failing/logger.rs
@@ -121,7 +121,7 @@ impl Logger {
         }
     }
 
-    // Returns chopped string where fisrt and third part are supposed
+    // Returns chopped string where first and third part are supposed
     // to be left as is but the second one is supposed to be highlighted
     fn get_highlighted_part(&self, line: &str) -> Option<[String;3]> {
         let (_row, col, len) = self.get_row_col_len()?;
@@ -157,7 +157,7 @@ impl Logger {
             let end = col.checked_add(len).unwrap_or(len);
             // If we are at the end of the code snippet and there is still some
             if end - 1 > code.chars().count() {
-                // We substract here 2 because 1 is the offset of col (starts at 1)
+                // We subtract here 2 because 1 is the offset of col (starts at 1)
                 // and other 1 is the new line character that we do not display
                 *overflow = (end - 2).checked_sub(code.chars().count()).unwrap_or(0);
             }

--- a/src/compiling/failing/message.rs
+++ b/src/compiling/failing/message.rs
@@ -134,7 +134,7 @@ impl Message {
         Self::new(meta.get_code(), &Self::get_full_trace(meta, pos), MessageType::Info)
     }
 
-    /* Attach additional infromation */
+    /* Attach additional information */
 
     /// Add message to an existing log
     pub fn message<T: AsRef<str>>(mut self, text: T) -> Self {

--- a/src/compiling/failing/mod.rs
+++ b/src/compiling/failing/mod.rs
@@ -1,6 +1,6 @@
 //! Module designed to help you send Errors
 //! 
-//! It's recommmended to use macros for this case, but you can use this module directly.
+//! It's recommended to use macros for this case, but you can use this module directly.
 
 pub mod failure;
 pub mod message;

--- a/src/compiling/failing/position_info.rs
+++ b/src/compiling/failing/position_info.rs
@@ -35,7 +35,7 @@ pub struct PositionInfo {
 }
 
 impl PositionInfo {
-    /// Create a new erorr from scratch
+    /// Create a new error from scratch
     pub fn new(meta: &impl Metadata, position: Position, len: usize) -> Self {
         let info = PositionInfo {
             position,
@@ -46,7 +46,7 @@ impl PositionInfo {
         info.updated_pos(meta)
     }
 
-    /// Create a new erorr at the end of file
+    /// Create a new error at the end of file
     pub fn at_eof(meta: &impl Metadata) -> Self {
         let info = PositionInfo {
             path: meta.get_path(),
@@ -57,7 +57,7 @@ impl PositionInfo {
         info.updated_pos(meta)
     }
 
-    /// Create a new erorr at given position
+    /// Create a new error at given position
     pub fn at_pos(path: Option<String>, (row, col): (usize, usize), len: usize) -> Self {
         PositionInfo {
             path,

--- a/src/compiling/lexing/compound_handler.rs
+++ b/src/compiling/lexing/compound_handler.rs
@@ -24,14 +24,14 @@ pub struct CompoundHandler {
 impl CompoundHandler {
     pub fn new(rules: &Rules) -> Self {
         CompoundHandler {
-            compound_tree: Self::generate_compunds(rules.compounds.clone()),
+            compound_tree: Self::generate_compounds(rules.compounds.clone()),
             is_triggered: false
         }
     }
 
     // Generates a tree where the key is the left item of 
     // the pair and values are all the right items of the pair
-    fn generate_compunds(word_pairs: Vec<(char, char)>) -> HashMap<char, Vec<char>> {
+    fn generate_compounds(word_pairs: Vec<(char, char)>) -> HashMap<char, Vec<char>> {
         let mut compound_tree = HashMap::new();
         for (left, right) in word_pairs {
             compound_tree

--- a/src/compiling/lexing/lexer.rs
+++ b/src/compiling/lexing/lexer.rs
@@ -60,7 +60,7 @@ impl Lexer {
         }
 
         // Getting position by word here would attempt to
-        // substract with overflow since the new line character
+        // subtract with overflow since the new line character
         // technically belongs to the previous line
         let (row, _col) = lex_state.reader.get_position();
         lex_state.lexem.push(Token {

--- a/src/compiling/parser/metadata.rs
+++ b/src/compiling/parser/metadata.rs
@@ -5,7 +5,7 @@ use crate::compiling::failing::position_info::PositionInfo;
 use serde::{Serialize, Deserialize};
 
 /// Default implementation of metadata. 
-/// This is useful for debuging or languages that are not too demanding.
+/// This is useful for debugging or languages that are not too demanding.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct DefaultMetadata {
     /// Current index in the token stream

--- a/src/compiling/parser/pattern.rs
+++ b/src/compiling/parser/pattern.rs
@@ -4,7 +4,7 @@ use super::{ Metadata, SyntaxModule };
 
 /// Matches one token with given word
 ///
-/// If token was matched succesfully - the word it contained is returned.
+/// If token was matched successfully - the word it contained is returned.
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
@@ -27,7 +27,7 @@ pub fn token<T: AsRef<str>>(meta: &mut impl Metadata, text: T) -> Result<String,
 
 /// Matches one token by defined function
 ///
-/// If token was matched succesfully - the word it contained is returned.
+/// If token was matched successfully - the word it contained is returned.
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
@@ -50,7 +50,7 @@ pub fn token_by(meta: &mut impl Metadata, cb: impl Fn(&String) -> bool) -> Resul
 
 /// Parses syntax module
 ///
-/// If syntax module was parsed succesfully - nothing is returned.
+/// If syntax module was parsed successfully - nothing is returned.
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
@@ -83,7 +83,7 @@ pub fn syntax<M: Metadata>(meta: &mut M, module: &mut impl SyntaxModule<M>) -> R
 
 /// Matches indentation
 ///
-/// If indentation was matched succesfully - the amount of spaces is returned.
+/// If indentation was matched successfully - the amount of spaces is returned.
 /// Otherwise detailed information is returned about where this happened.
 /// # Example
 /// ```
@@ -104,7 +104,7 @@ pub fn indent(meta: &mut impl Metadata) -> Result<usize, Failure> {
 
 /// Matches indentation with provided size
 ///
-/// If indentation was identified succesfully return the std::cmp::Ordering
+/// If indentation was identified successfully return the std::cmp::Ordering
 /// depending on whether the amount of spaces detected was smaller, equal or greater.
 /// Otherwise detailed information is returned about where this happened.
 /// # Example

--- a/src/compiling/parser/preset.rs
+++ b/src/compiling/parser/preset.rs
@@ -84,7 +84,7 @@ pub fn numeric(meta: &mut impl Metadata, extend: Vec<char>) -> Result<String, Fa
 
 /// Match an integer
 /// 
-/// Matches a positive or negetive integer.
+/// Matches a positive or negative integer.
 /// If desired - one can extend this implementation with other chars.
 pub fn integer(meta: &mut impl Metadata, extend: Vec<char>) -> Result<String, Failure> {
     match meta.get_current_token() {


### PR DESCRIPTION
<code>[typos](https://github.com/crate-ci/typos) -w</code>
```
error: `negetive` should be `negative`
   ╭▸ ./src/compiling/parser/preset.rs:87:27
   │
87 │ /// Matches a positive or negetive integer.
   ╰╴                          ━━━━━━━━
error: `succesfully` should be `successfully`
  ╭▸ ./src/compiling/parser/pattern.rs:7:26
  │
7 │ /// If token was matched succesfully - the word it contained is returned.
  ╰╴                         ━━━━━━━━━━━
error: `succesfully` should be `successfully`
   ╭▸ ./src/compiling/parser/pattern.rs:30:26
   │
30 │ /// If token was matched succesfully - the word it contained is returned.
   ╰╴                         ━━━━━━━━━━━
error: `succesfully` should be `successfully`
   ╭▸ ./src/compiling/parser/pattern.rs:53:33
   │
53 │ /// If syntax module was parsed succesfully - nothing is returned.
   ╰╴                                ━━━━━━━━━━━
error: `succesfully` should be `successfully`
   ╭▸ ./src/compiling/parser/pattern.rs:86:32
   │
86 │ /// If indentation was matched succesfully - the amount of spaces is returned.
   ╰╴                               ━━━━━━━━━━━
error: `succesfully` should be `successfully`
    ╭▸ ./src/compiling/parser/pattern.rs:107:35
    │
107 │ /// If indentation was identified succesfully return the std::cmp::Ordering
    ╰╴                                  ━━━━━━━━━━━
error: `debuging` should be `debugging`
  ╭▸ ./src/compiling/parser/metadata.rs:8:24
  │
8 │ /// This is useful for debuging or languages that are not too demanding.
  ╰╴                       ━━━━━━━━
error: `substract` should be `subtract`
   ╭▸ ./src/compiling/lexing/lexer.rs:63:12
   │
63 │         // substract with overflow since the new line character
   ╰╴           ━━━━━━━━━
error: `erorr` should be `error`
   ╭▸ ./src/compiling/failing/position_info.rs:38:22
   │
38 │     /// Create a new erorr from scratch
   ╰╴                     ━━━━━
error: `erorr` should be `error`
   ╭▸ ./src/compiling/failing/position_info.rs:49:22
   │
49 │     /// Create a new erorr at the end of file
   ╰╴                     ━━━━━
error: `erorr` should be `error`
   ╭▸ ./src/compiling/failing/position_info.rs:60:22
   │
60 │     /// Create a new erorr at given position
   ╰╴                     ━━━━━
error: `compunds` should be `compounds`
   ╭▸ ./src/compiling/lexing/compound_handler.rs:27:43
   │
27 │             compound_tree: Self::generate_compunds(rules.compounds.clone()),
   ╰╴                                          ━━━━━━━━
error: `recommmended` should be `recommended`
  ╭▸ ./src/compiling/failing/mod.rs:3:10
  │
3 │ //! It's recommmended to use macros for this case, but you can use this module directly.
  ╰╴         ━━━━━━━━━━━━
error: `compunds` should be `compounds`
   ╭▸ ./src/compiling/lexing/compound_handler.rs:34:17
   │
34 │     fn generate_compunds(word_pairs: Vec<(char, char)>) -> HashMap<char, Vec<char>> {
   ╰╴                ━━━━━━━━
error: `infromation` should be `information`
    ╭▸ ./src/compiling/failing/message.rs:137:26
    │
137 │     /* Attach additional infromation */
    ╰╴                         ━━━━━━━━━━━
error: `fisrt` should be `first`
    ╭▸ ./src/compiling/failing/logger.rs:124:37
    │
124 │     // Returns chopped string where fisrt and third part are supposed
    ╰╴                                    ━━━━━
error: `substract` should be `subtract`
    ╭▸ ./src/compiling/failing/logger.rs:160:23
    │
160 │                 // We substract here 2 because 1 is the offset of col (starts at 1)
    ╰╴                      ━━━━━━━━━
```